### PR TITLE
Fix script references and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SoACer is a three-stage pipeline (Pre-processing → Inference → Post-processi
 ### Inference
 
 ```bash
-python src/soacer_inference.py \
+python src/inference/SoACer_pipeline.py \
   --input_type url \
   --input_value "https://example.com" \
   --output_file results.json
@@ -99,7 +99,7 @@ Below are three main experiment workflows. Each section assumes you have a `scri
 This step produces extractive summaries for every website in SoAC (used later for training/inference). By default, we extract 20 sentences per document.
 
 ```bash
-bash scripts/generate_summaries.sh \
+bash scripts/summary/generate_summary.sh \
   --input_dir data/raw_html/ \
   --output_dir data/summaries/ \
   --sentences_count 20
@@ -121,7 +121,7 @@ Train SoACer on the summarized corpus. By default, the hyperparameters are:
 * **Dropout**: 0.3&#x20;
 
 ```bash
-bash scripts/train_soacer.sh \
+bash scripts/classification/train_classifier.sh \
   --train_data data/summaries/train.jsonl \
   --valid_data data/summaries/validation.jsonl \
   --model_output_dir models/soacer_20sent/ \
@@ -139,7 +139,7 @@ To compare full-text classification (subsampled to ≤ 7,000 tokens) versus summ
 
 ```bash
 # Full-text variant (using Llama-3.2-1B, subsampled dataset)
-bash scripts/run_ablation.sh \
+bash scripts/ablation/run_ablation.sh \
   --mode full_text \
   --train_data data/full_text/train_subsampled.jsonl \
   --valid_data data/full_text/valid_subsampled.jsonl \
@@ -147,7 +147,7 @@ bash scripts/run_ablation.sh \
   --model_output_dir models/ablation_fulltext/
 
 # Summary-based variant (same Llama-3.2-1B, using 20-sentence summaries)
-bash scripts/run_ablation.sh \
+bash scripts/ablation/run_ablation.sh \
   --mode summary \
   --train_data data/summaries/train.jsonl \
   --valid_data data/summaries/validation.jsonl \
@@ -176,7 +176,7 @@ All code is implemented in Python 3 (≥ 3.8) with PyTorch 2.x and Hugging Face 
   3. FC layer (256 units) → BatchNorm → LeakyReLU → Dropout 0.3
   4. Final linear → 10-way softmax .
 
-Detailed hyperparameters are in `scripts/train_soacer.sh` (and appendix of the paper).
+Detailed hyperparameters are in `scripts/classification/train_classifier.sh` (and appendix of the paper).
 
 ---
 

--- a/scripts/SoACer/SoACer_pipline.sh
+++ b/scripts/SoACer/SoACer_pipline.sh
@@ -11,4 +11,4 @@ fi
 INPUT=$1
 OUTPUT_DIR=$2
 
-python3 main.py --input "$INPUT" --output_dir "$OUTPUT_DIR"
+python3 src/inference/SoACer_pipeline.py --input "$INPUT" --output_dir "$OUTPUT_DIR"

--- a/scripts/SoACer/SoACer_pipline_async.sh
+++ b/scripts/SoACer/SoACer_pipline_async.sh
@@ -10,4 +10,4 @@ fi
 INPUT="$1"
 OUTPUT="$2"
 
-python3 main.py --input_txt "$INPUT" --output_dir "$OUTPUT"
+python3 src/inference/SoACer_pipeline_async.py --input_txt "$INPUT" --output_dir "$OUTPUT"

--- a/scripts/ablation/run_ablation.sh
+++ b/scripts/ablation/run_ablation.sh
@@ -22,11 +22,11 @@ DEVICE="cuda:0"
 # ───────────────────────────────────────────────
 # Paths
 # ───────────────────────────────────────────────
-TRAIN_TEMPLATE="/data/sxs7285/Porjects_code/thesis/SoAC/websector/${MODEL_NAME}_{}"
-VAL_TEST_DIR="/data/sxs7285/Porjects_code/thesis/SoAC/websector/${MODEL_NAME}_12"
-RESULTS_BASE="/data/sxs7285/Porjects_code/thesis/SoAC/ablation_results/${MODEL_NAME}"
+TRAIN_TEMPLATE="data/websector/${MODEL_NAME}_{}"
+VAL_TEST_DIR="data/websector/${MODEL_NAME}_12"
+RESULTS_BASE="ablation_results/${MODEL_NAME}"
 
-PYTHON_SCRIPT="/data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/training/run_ablation_train_eval.py"
+PYTHON_SCRIPT="src/Ablation/run_ablation_train_eval.py"
 
 echo "[ABLATION] Running seed(s): $SEEDS for $MODEL_NAME"
 

--- a/scripts/ablation/run_embedding.sh
+++ b/scripts/ablation/run_embedding.sh
@@ -9,10 +9,10 @@ MODEL_ID=${1:-"meta-llama/Meta-Llama-3-8B"}
 BATCH_SIZE=${2:-1}
 MAX_LEN=${3:-1024}
 TASK_NAME=${4:-"model_embeddings"}
-OUTPUT_BASE=${5:-"/data/soac/embeddings"}
+OUTPUT_BASE=${5:-"ablation/embeddings"}
 
 PYTHON="python3"
-SCRIPT_PATH="/data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/training/embedding_extractor.py"
+SCRIPT_PATH="src/Ablation/embedding/ablation_emb.py"
 
 echo "[EMBEDDING] Running embedding extraction..."
 echo "Model: $MODEL_ID"

--- a/scripts/classification/generate_embeddings.sh
+++ b/scripts/classification/generate_embeddings.sh
@@ -9,14 +9,14 @@ set -u
 # --------- DEFAULT CONFIGS (overridable) ---------
 MODEL_ID="${MODEL_ID:-meta-llama/Meta-Llama-3-8B}"
 TASK_NAME="${TASK_NAME:-model_embeddings}"
-OUTPUT_DIR="${OUTPUT_DIR:-/data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/SoACer_training/embeddings/model_embeddings}"
+OUTPUT_DIR="${OUTPUT_DIR:-embeddings/model_embeddings}"
 MAX_LEN="${MAX_LEN:-1024}"
 BATCH_SIZE="${BATCH_SIZE:-8}"
 # --------------------------------------------------
 
 echo "[INFO] Generating embeddings using $MODEL_ID..."
 
-python3 /data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/SoACer_training/embeddings/generate_embeddings.py \
+python3 src/SoACer_training/embeddings/generate_embeddings.py \
   --model_id "$MODEL_ID" \
   --task "$TASK_NAME" \
   --output_base "$OUTPUT_DIR" \

--- a/scripts/classification/train_classifier.sh
+++ b/scripts/classification/train_classifier.sh
@@ -31,10 +31,10 @@ LEARNING_RATE=1e-4
 VAL_INTERVAL=1
 
 # Root folder containing all embedding subdirectories
-EMBEDDINGS_ROOT="/data/sxs7285/Porjects_code/thesis/DocEng/classification/embeddings"
+EMBEDDINGS_ROOT="classification/embeddings"
 
 # Root folder where training results, metrics, and confusion matrices will be saved
-RESULTS_ROOT="/data/sxs7285/Porjects_code/thesis/DocEng/classification/results"
+RESULTS_ROOT="classification/results"
 
 # W&B project name (for organizing multiple runs)
 WANDB_PROJECT="SoAC"
@@ -49,7 +49,7 @@ WANDB_ENTITY="your_wandb_entity"
 LOG_DIR="./wandb_logs"
 
 # === EXECUTION ===
-python3 /data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/SoACer_training/train_single_model.py \
+python3 src/SoACer_training/train_single_model.py \
   --model_variant "$MODEL_VARIANT" \
   --embed_size "$EMBED_SIZE" \
   --common_dim "$COMMON_DIM" \

--- a/scripts/summary/generate_summary.sh
+++ b/scripts/summary/generate_summary.sh
@@ -10,7 +10,7 @@ PYTHON="python3"
 echo "[SUMMARY] Running LexRank with ${SUMMARY_LENGTH} sentences and ${NUM_WORKERS} workers..."
 mkdir -p "$OUTPUT_DIR"
 
-$PYTHON /data/sxs7285/Porjects_code/thesis/DocEng/SoAC-DocEng/src/summary/lexrank.py \
+$PYTHON src/summary/lexrank.py \
     --output_dir "$OUTPUT_DIR" \
     --splits train validation test \
     --sentences_count "$SUMMARY_LENGTH" \


### PR DESCRIPTION
## Summary
- fix README commands for inference, summary generation, training, and ablation
- update SoACer pipeline scripts to call the correct modules
- use repo-relative paths in summary, classification, and ablation scripts

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840c255f98c832eb567729d0a2d0c21